### PR TITLE
Add CHANGELOG.md for initial release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [0.1.0] – 2025-08-27
+### Added
+- First beta release of Database Manager
+- Define schema in code
+- Compile a standalone Database Manager app
+- Run to ensure database exists and matches model
+- Creates or alters tables and fields as required
+
+**Requirements:** DataFlex 25.0+  
+**Status:** Beta — feedback welcome
+
+


### PR DESCRIPTION
Adds an initial CHANGELOG.md to track release history.
Includes entry for v0.1.0 (initial beta release).
